### PR TITLE
Ensure columns are typecast as expected

### DIFF
--- a/pyvoteview/core.py
+++ b/pyvoteview/core.py
@@ -59,8 +59,10 @@ def get_records_by_congress(
     record_votes = _cast_columns(read_csv(url_votes, null_values=["N/A"]))
     record_members = _cast_columns(read_csv(url_members, null_values=["N/A"]))
     record_rollcalls = _cast_columns(
-        read_csv(url_rollcalls, null_values=["N/A"])
-    ).rename({"nominate_log_likelihood": "log_likelihood"})
+        read_csv(url_rollcalls, null_values=["N/A"]).rename(
+            {"nominate_log_likelihood": "log_likelihood"}
+        )
+    )
 
     return record_votes.join(
         record_members, on=["congress", "chamber", "icpsr"], coalesce=True


### PR DESCRIPTION
I realized that since we're expecting to use the defined schema in _utilities.py, we may come across a strange situation where "log_likelihood" is not cast correctly.  This should fix that potential problem.